### PR TITLE
offline: Address issues with dbus connections

### DIFF
--- a/src/daemonprivate.cpp
+++ b/src/daemonprivate.cpp
@@ -92,7 +92,7 @@ void DaemonPrivate::getAllProperties()
     message << PK_OFFLINE_INTERFACE;
     QDBusConnection::systemBus().callWithCallback(message,
                                                   offline,
-                                                  SLOT(updateProperties(QVariantMap)));
+                                                  SLOT(initializeProperties(QVariantMap)));
 }
 
 void DaemonPrivate::propertiesChanged(const QString &interface, const QVariantMap &properties, const QStringList &invalidatedProperties)
@@ -102,7 +102,7 @@ void DaemonPrivate::propertiesChanged(const QString &interface, const QVariantMa
     if (interface == PK_NAME) {
         updateProperties(properties);
     } else if (interface == PK_OFFLINE_INTERFACE) {
-        offline->d_ptr->updateProperties(properties);
+        offline->d_ptr->updateProperties(interface, properties, invalidatedProperties);
     } else {
         qCWarning(PACKAGEKITQT_DAEMON) << "Unknown PackageKit interface:" << interface;
     }

--- a/src/offline.cpp
+++ b/src/offline.cpp
@@ -31,7 +31,7 @@ Offline::Offline(QObject *parent) : QObject(parent)
                                          DBUS_PROPERTIES,
                                          QLatin1String("PropertiesChanged"),
                                          this,
-                                         SLOT(propertiesChanged(QString,QVariantMap,QStringList)));
+                                         SLOT(updateProperties(QString,QVariantMap,QStringList)));
 }
 
 Offline::~Offline()
@@ -145,7 +145,7 @@ void Offline::getPrepared()
     });
 }
 
-void OfflinePrivate::updateProperties(const QVariantMap &properties)
+void OfflinePrivate::initializeProperties(const QVariantMap &properties)
 {
     Q_Q(Offline);
 
@@ -182,6 +182,20 @@ void OfflinePrivate::updateProperties(const QVariantMap &properties)
     if (!properties.isEmpty()) {
         q->changed();
     }
+}
+
+void OfflinePrivate::updateProperties(const QString &interface, const QVariantMap &properties, const QStringList &invalidate)
+{
+    if(interface != PK_OFFLINE_INTERFACE) {
+        qCWarning(PACKAGEKITQT_OFFLINE) << "Cannot process" << interface << "as" << PK_OFFLINE_INTERFACE;
+        return;
+    }
+
+    if (!invalidate.isEmpty()) {
+        qCWarning(PACKAGEKITQT_OFFLINE) << "Properties could not be invalidated" << interface << invalidate;
+    }
+
+    initializeProperties(properties);
 }
 
 #include "moc_offline.cpp"

--- a/src/offline.h
+++ b/src/offline.h
@@ -132,7 +132,8 @@ protected:
     explicit Offline(QObject *parent = nullptr);
 
 private:
-    Q_PRIVATE_SLOT(d_func(), void updateProperties(QVariantMap))
+    Q_PRIVATE_SLOT(d_func(), void initializeProperties(QVariantMap))
+    Q_PRIVATE_SLOT(d_func(), void updateProperties(QString, QVariantMap, QStringList))
 
     OfflinePrivate *d_ptr;
 };

--- a/src/offline_p.h
+++ b/src/offline_p.h
@@ -33,7 +33,8 @@ public:
     {
     }
 
-    void updateProperties(const QVariantMap &properties);
+    void initializeProperties(const QVariantMap &properties);
+    void updateProperties(const QString &interface, const QVariantMap &properties, const QStringList &invalidate);
 
     Offline *q_ptr;
     OrgFreedesktopPackageKitOfflineInterface iface;


### PR DESCRIPTION
As I added some extra debug information in QtDBus, I realised that there's a number of connects that were not effective. This change addresses that by not using the same method for processing GetAll and the propertiesChanged signal.

This is the debug information in question: https://codereview.qt-project.org/c/qt/qtbase/+/443753