### PR TITLE
.gitignore KDE's kdesrc-build and extra-cmake-modules create /compile…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 *~
 *.o
 *.moc
+/compile_commands.json


### PR DESCRIPTION
…_commands.json

File /compile_commands.json is created by default.
https://community.kde.org/Get_Involved/development/Easy#Just_running_kdesrc-build_should_not_create_.22Unstaged_Changes.22_in_the_local_clone_of_a_KDE_git_repo