### PR TITLE
Add explicit CMake option to control Qt major version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,15 @@ include(GNUInstallDirs)
 
 set(QPACKAGEKIT_API_LEVEL "1")
 
-find_package(QT NAMES Qt6 Qt5 NO_MODULE REQUIRED COMPONENTS Core DBus)
+option(BUILD_WITH_QT6 "Use Qt6 instead of Qt5" OFF)
+
+if(BUILD_WITH_QT6)
+  set(QT_VERSION_MAJOR 6)
+else()
+  set(QT_VERSION_MAJOR 5)
+endif()
+
+find_package(Qt${QT_VERSION_MAJOR} 5.10 REQUIRED COMPONENTS Core DBus)
 
 add_definitions(
     -DQT_NO_KEYWORDS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,7 +1,5 @@
 # CMakeLists for PackageKit-Qt library
 
-find_package(Qt${QT_VERSION_MAJOR} 5.10 REQUIRED COMPONENTS Core DBus)
-
 set(packagekitqt_HEADERS
     Daemon
     Transaction


### PR DESCRIPTION
Currently Qt5 or Qt6 is implicitly picked based on what is available

That's brittle and problematic though when both are installed

Instead default to Qt5 and add an option to use Qt6 instead