### PR TITLE
Return early when `role == Transaction::RoleUnknown`

### DIFF
--- a/src/transactionprivate.cpp
+++ b/src/transactionprivate.cpp
@@ -88,8 +88,6 @@ void TransactionPrivate::runQueuedTransaction()
 
     QDBusPendingReply<> reply;
     switch (role) {
-    case Transaction::RoleUnknown:
-        return;
     case Transaction::RoleAcceptEula:
         reply = p->AcceptEula(eulaId);
         break;
@@ -187,7 +185,7 @@ void TransactionPrivate::runQueuedTransaction()
         reply = p->UpgradeSystem(transactionFlags, upgradeDistroId, upgradeKind);
         break;
     default:
-        break;
+        return;
     }
 
     if (reply.isFinished() && reply.isError()) {

--- a/src/transactionprivate.cpp
+++ b/src/transactionprivate.cpp
@@ -88,6 +88,8 @@ void TransactionPrivate::runQueuedTransaction()
 
     QDBusPendingReply<> reply;
     switch (role) {
+    case Transaction::RoleUnknown:
+        return;
     case Transaction::RoleAcceptEula:
         reply = p->AcceptEula(eulaId);
         break;


### PR DESCRIPTION
An alternative to #45.