### PR TITLE
Fix check for PackageKit D-Bus specs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,7 @@ find_path(PK_INTERFACES_DIR org.freedesktop.PackageKit.xml
 set(PK_INTERFACE_XML "${PK_INTERFACES_DIR}/org.freedesktop.PackageKit.xml")
 set(PK_TRANSACTION_INTERFACE_XML "${PK_INTERFACES_DIR}/org.freedesktop.PackageKit.Transaction.xml")
 
-if (NOT PK_INTERFACE_XML OR NOT PK_TRANSACTION_INTERFACE_XML)
+if (NOT EXISTS "${PK_INTERFACE_XML}" OR NOT EXISTS "${PK_TRANSACTION_INTERFACE_XML}")
 	message (FATAL_ERROR "Unable to find PackageKit DBus specifications! Please install PackageKit to continue!")
 endif ()
 


### PR DESCRIPTION
This fixes an issue with CMake failing to detect that PackageKit isn't installed.

Currently, it checks if the `PK_INTERFACE_XML` or `PK_TRANSACTION_INTERFACE_XML` variables are set, and not that the files with those paths exist.

If the `find_path` call fails, `PK_INTERFACE_XML` will be set to `PK_INTERFACES_DIR-NOTFOUND/org.freedesktop.PackageKit.xml`, which isn't empty (and likewise for `PK_TRANSACTION_INTERFACE_XML`), so the condition is never true.