### PR TITLE
Draft: Port static methods of Transaction & Daemon from QString to QStringView

### DIFF
--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -298,22 +298,22 @@ uint Daemon::versionMicro()
     return global()->d_ptr->versionMicro;
 }
 
-QString Daemon::packageName(const QString &packageID)
+QStringView Daemon::packageName(QStringView packageID)
 {
     return Transaction::packageName(packageID);
 }
 
-QString Daemon::packageVersion(const QString &packageID)
+QStringView Daemon::packageVersion(QStringView packageID)
 {
     return Transaction::packageVersion(packageID);
 }
 
-QString Daemon::packageArch(const QString &packageID)
+QStringView Daemon::packageArch(QStringView packageID)
 {
     return Transaction::packageArch(packageID);
 }
 
-QString Daemon::packageData(const QString &packageID)
+QStringView Daemon::packageData(QStringView packageID)
 {
     return Transaction::packageData(packageID);
 }

--- a/src/daemon.h
+++ b/src/daemon.h
@@ -45,7 +45,7 @@ class Offline;
  * This class holds all the functions enabling the user to interact with the PackageKit daemon.
  *
  * Most methods are static so that you can just call Daemon::backendName() to get the name of the backend.
- * 
+ *
  * This class is a singleton, its constructor is private. Call Daemon::global() to get
  * an instance of the Daemon object, you only need Daemon::global() when connecting to the signals
  * of this class.
@@ -268,23 +268,23 @@ public:
     /**
      * Returns the package name from the \p packageID
      */
-    Q_INVOKABLE static QString packageName(const QString &packageID);
+    Q_INVOKABLE static QStringView packageName(QStringView packageID);
 
     /**
      * Returns the package version from the \p packageID
      */
-    Q_INVOKABLE static QString packageVersion(const QString &packageID);
+    Q_INVOKABLE static QStringView packageVersion(QStringView packageID);
 
     /**
      * Returns the package arch from the \p packageID
      */
-    Q_INVOKABLE static QString packageArch(const QString &packageID);
+    Q_INVOKABLE static QStringView packageArch(QStringView packageID);
 
     /**
      * Returns the package data from the \p packageID
      */
-    Q_INVOKABLE static QString packageData(const QString &packageID);
-    
+    Q_INVOKABLE static QStringView packageData(QStringView packageID);
+
     static QString enumToString(const QMetaObject &metaObject, int value, const char *enumName);
 
     /**
@@ -297,7 +297,7 @@ public:
     }
 
     static int enumFromString(const QMetaObject &metaObject, const QString &str, const char *enumName);
-    
+
     template<class T> static int enumFromString(const QString &str, const char *enumName)
     {
         return enumFromString(T::staticMetaObject, str, enumName);

--- a/src/transaction.cpp
+++ b/src/transaction.cpp
@@ -192,16 +192,16 @@ QDBusPendingReply<> Transaction::cancel()
     return QDBusPendingReply<>();
 }
 
-QString Transaction::packageName(const QString &packageID)
+QStringView Transaction::packageName(QStringView packageID)
 {
-    QString ret;
+    QStringView ret;
     ret = packageID.left(packageID.indexOf(QLatin1Char(';')));
     return ret;
 }
 
-QString Transaction::packageVersion(const QString &packageID)
+QStringView Transaction::packageVersion(QStringView packageID)
 {
-    QString ret;
+    QStringView ret;
     int start = packageID.indexOf(QLatin1Char(';'));
     if (start == -1) {
         return ret;
@@ -215,9 +215,9 @@ QString Transaction::packageVersion(const QString &packageID)
     return ret;
 }
 
-QString Transaction::packageArch(const QString &packageID)
+QStringView Transaction::packageArch(QStringView packageID)
 {
-    QString ret;
+    QStringView ret;
     int start = packageID.indexOf(QLatin1Char(';'));
     if (start == -1) {
         return ret;
@@ -235,9 +235,9 @@ QString Transaction::packageArch(const QString &packageID)
     return ret;
 }
 
-QString Transaction::packageData(const QString &packageID)
+QStringView Transaction::packageData(QStringView packageID)
 {
-    QString ret;
+    QStringView ret;
     int start = packageID.indexOf(QLatin1Char(';'));
     if (start == -1) {
         return ret;
@@ -289,7 +289,7 @@ qulonglong Transaction::downloadSizeRemaining() const
 {
     Q_D(const Transaction);
     return d->downloadSizeRemaining;
-}    
+}
 
 Transaction::Role Transaction::role() const
 {
@@ -372,9 +372,9 @@ Transaction::InternalError Transaction::parseError(const QString &errorName)
     if (error.startsWith(QLatin1String("org.freedesktop.packagekit."))) {
         return Transaction::InternalErrorFailedAuth;
     }
-    
+
     error.remove(QLatin1String("org.freedesktop.PackageKit.Transaction."));
-    
+
     if (error.startsWith(QLatin1String("PermissionDenied")) ||
         error.startsWith(QLatin1String("RefusedByPolicy"))) {
         return Transaction::InternalErrorFailedAuth;

--- a/src/transaction.h
+++ b/src/transaction.h
@@ -552,7 +552,7 @@ public:
      * \return speed bits per second, or 0 if not known.
      */
     uint speed() const;
-    
+
     /**
      * Returns the number of bytes remaining to download
      * \return bytes to download, or 0 if nothing is left to download.
@@ -666,22 +666,22 @@ public:
     /**
      * Returns the package name from the \p packageID
      */
-    static QString packageName(const QString &packageID);
+    static QStringView packageName(QStringView packageID);
 
     /**
      * Returns the package version from the \p packageID
      */
-    static QString packageVersion(const QString &packageID);
+    static QStringView packageVersion(QStringView packageID);
 
     /**
      * Returns the package arch from the \p packageID
      */
-    static QString packageArch(const QString &packageID);
+    static QStringView packageArch(QStringView packageID);
 
     /**
      * Returns the package data from the \p packageID
      */
-    static QString packageData(const QString &packageID);
+    static QStringView packageData(QStringView packageID);
 
 Q_SIGNALS:
     void allowCancelChanged();


### PR DESCRIPTION
This is API and ABI breaking change. It optimizes extra allocations for all four methods where returned value is a slice of their input string.

Fixes #55