### PR TITLE
offline: Ensure the enum is registered

### DIFF
--- a/src/offline.cpp
+++ b/src/offline.cpp
@@ -26,6 +26,7 @@ using namespace PackageKit;
 Offline::Offline(QObject *parent) : QObject(parent)
   , d_ptr(new OfflinePrivate(this))
 {
+    qRegisterMetaType<Transaction::Role>();
     QDBusConnection::systemBus().connect(PK_NAME,
                                          PK_PATH,
                                          DBUS_PROPERTIES,


### PR DESCRIPTION
Otherwise we get a crash saying:
[fatal] discover (unknown:0) - QDBusPendingReply: type PackageKit::Transaction::Role is not registered with QtDBus

See https://bugs.kde.org/show_bug.cgi?id=508271