### PR TITLE
Follow-up fix for Offline::getResults()

### DIFF
--- a/src/offline.cpp
+++ b/src/offline.cpp
@@ -26,7 +26,6 @@ using namespace PackageKit;
 Offline::Offline(QObject *parent) : QObject(parent)
   , d_ptr(new OfflinePrivate(this))
 {
-    qRegisterMetaType<Transaction::Role>();
     QDBusConnection::systemBus().connect(PK_NAME,
                                          PK_PATH,
                                          DBUS_PROPERTIES,

--- a/src/offline.cpp
+++ b/src/offline.cpp
@@ -23,6 +23,47 @@ Q_DECLARE_LOGGING_CATEGORY(PACKAGEKITQT_OFFLINE)
 
 using namespace PackageKit;
 
+Offline::Results::Results(const QDBusPendingCall &call)
+    : m_reply(call)
+{
+    m_reply.waitForFinished();
+}
+
+bool Offline::Results::isError() const
+{
+    return m_reply.isError();
+}
+
+bool Offline::Results::success() const
+{
+    return m_reply.argumentAt<0>();
+}
+
+QStringList Offline::Results::packageIds() const
+{
+    return m_reply.argumentAt<1>();
+}
+
+Transaction::Role Offline::Results::role() const
+{
+    return static_cast<Transaction::Role>(m_reply.argumentAt<2>());
+}
+
+qulonglong Offline::Results::timeFinished() const
+{
+    return m_reply.argumentAt<3>();
+}
+
+Transaction::Error Offline::Results::error() const
+{
+    return static_cast<Transaction::Error>(m_reply.argumentAt<4>());
+}
+
+QString Offline::Results::errorDescription() const
+{
+    return m_reply.argumentAt<5>();
+}
+
 Offline::Offline(QObject *parent) : QObject(parent)
   , d_ptr(new OfflinePrivate(this))
 {
@@ -131,7 +172,7 @@ QDBusPendingReply<> Offline::triggerUpgrade(Action action)
     return QDBusConnection::systemBus().asyncCall(msg, 24 * 60 * 1000 * 1000);
 }
 
-QDBusPendingReply<bool, QStringList, Transaction::Role, qint64, Transaction::Error, QString> Offline::getResults()
+Offline::Results Offline::getResults()
 {
     // Manually invoke dbus because the qdbusxml2cpp does not allow
     // setting the ALLOW_INTERACTIVE_AUTHORIZATION flag

--- a/src/offline.h
+++ b/src/offline.h
@@ -48,6 +48,26 @@ public:
     };
     Q_ENUM(Action)
 
+    /**
+     * Wrapper class representing the returning value of getResults()
+     */
+    class Results
+    {
+        friend class Offline;
+    public:
+        Results(const QDBusPendingCall &call);
+
+        bool isError() const;
+        bool success() const;
+        QStringList packageIds() const;
+        Transaction::Role role() const;
+        qulonglong timeFinished() const;
+        Transaction::Error error() const;
+        QString errorDescription() const;
+    private:
+        QDBusPendingReply<bool, QStringList, unsigned, qulonglong, unsigned, QString> m_reply;
+    };
+
     ~Offline();
 
     Q_PROPERTY(QVariantMap preparedUpgrade READ preparedUpgrade NOTIFY changed)
@@ -104,7 +124,7 @@ public:
     /**
      * Returns the information about the last offline action performed.
      */
-    QDBusPendingReply<bool, QStringList, Transaction::Role, qint64, Transaction::Error, QString> getResults();
+    Results getResults();
 
     /**
      * Cancels the offline update so the next boot procceeds as normal.


### PR DESCRIPTION
This is, IMO, a better fix for #59 

- It handles both `Transaction::Role` and `Transaction::Error` enums
- It does not require registering the metatype
- It is cleaner from the user perspective as it is now possible to call named getters rather than `reply.argumentAt(n)`
- It actually works, while #59 didn't fix the problem for me.