### PR TITLE
cmake: Add a convenience alias to packagekitqt6

### DIFF
--- a/src/modules/packagekit-qt-config.cmake.in
+++ b/src/modules/packagekit-qt-config.cmake.in
@@ -2,6 +2,8 @@
 
 check_required_components(Qt@QT_VERSION_MAJOR@DBus)
 
-SET(PackageKitQt@QT_VERSION_MAJOR@_LIBRARIES "PK::packagekitqt@QT_VERSION_MAJOR@")
+SET(PackageKitQt@QT_VERSION_MAJOR@_LIBRARIES "PK::packagekitqt")
 
 include("${CMAKE_CURRENT_LIST_DIR}/PackageKitQtTargets.cmake")
+
+add_library(PK::packagekitqt6 ALIAS PK::packagekitqt)


### PR DESCRIPTION
For apps that still use it.
Keep it an alias so it's easier to do in the future.