### PR TITLE
Fix assert because Transaction::Role is not registered with QtDBus

### DIFF
--- a/src/daemon.cpp
+++ b/src/daemon.cpp
@@ -34,6 +34,42 @@ Q_DECLARE_METATYPE(QList<PackageKit::PkPackage>);
 Q_DECLARE_METATYPE(PackageKit::PkDetail);
 Q_DECLARE_METATYPE(QList<PackageKit::PkDetail>);
 
+static const QDBusArgument &operator<<(QDBusArgument &argument, const PackageKit::Transaction::Role &role)
+{
+    argument.beginStructure();
+    argument << static_cast<qlonglong>(role);
+    argument.endStructure();
+    return argument;
+}
+
+static const QDBusArgument &operator>>(const QDBusArgument &argument, PackageKit::Transaction::Role &role)
+{
+    argument.beginStructure();
+    qlonglong result = 0;
+    argument >> result;
+    role = static_cast<PackageKit::Transaction::Role>(result);
+    argument.endStructure();
+    return argument;
+}
+
+static const QDBusArgument &operator<<(QDBusArgument &argument, const PackageKit::Transaction::Status &status)
+{
+    argument.beginStructure();
+    argument << static_cast<qlonglong>(status);
+    argument.endStructure();
+    return argument;
+}
+
+static const QDBusArgument &operator>>(const QDBusArgument &argument, PackageKit::Transaction::Status &status)
+{
+    argument.beginStructure();
+    qlonglong result = 0;
+    argument >> result;
+    status = static_cast<PackageKit::Transaction::Status>(result);
+    argument.endStructure();
+    return argument;
+}
+
 static const QDBusArgument &operator<<(QDBusArgument &argument, const PackageKit::PkPackage &pkg)
 {
     argument.beginStructure();
@@ -122,6 +158,8 @@ Daemon::Daemon(QObject *parent) :
                                          this,
                                          SLOT(propertiesChanged(QString,QVariantMap,QStringList)));
 
+    qDBusRegisterMetaType<PackageKit::Transaction::Role>();
+    qDBusRegisterMetaType<PackageKit::Transaction::Status>();
     qDBusRegisterMetaType<PackageKit::PkPackage>();
     qDBusRegisterMetaType<QList<PackageKit::PkPackage>>();
     qDBusRegisterMetaType<PackageKit::PkDetail>();


### PR DESCRIPTION
Its needed to explicit register the Q_ENUM and provide streaming operators. While on it also register the Transaction::Status. QFlags are, according to the documentation, already proper registered. With this patch plasma-discover doesn't assert for me anymore.

Backtrace was:

```
    QDBusPendingReply: type PackageKit::Transaction::Role is not registered with QtDBus
    #0  __pthread_kill_implementation (threadid=140737351288288, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
    #1  0x00007ffff4c17e64 in __pthread_kill_internal (threadid=<optimized out>, signo=6) at ./nptl/pthread_kill.c:89
    #2  0x00007ffff4bc6980 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
    #3  0x00007ffff4bb1ac4 in __GI_abort () at ./stdlib/abort.c:73
    #4  0x00007ffff50cb468 in qAbort () at /home/snoopy/kde/src/qtbase/src/corelib/global/qassert.cpp:46
    #5  0x00007ffff50ee96c in qt_message_fatal<QString&> (context=..., message=...) at /home/snoopy/kde/src/qtbase/src/corelib/global/qlogging.cpp:2122
    #6  qt_message (msgType=msgType@entry=QtFatalMsg, context=..., msg=msg@entry=0x7ffff575e648 "QDBusPendingReply: type %s is not registered with QtDBus", ap=...)
        at /home/snoopy/kde/src/qtbase/src/corelib/global/qlogging.cpp:381
    #7  0x00007ffff50cbcf4 in QMessageLogger::fatal (this=this@entry=0x7fffffff81b0, msg=msg@entry=0x7ffff575e648 "QDBusPendingReply: type %s is not registered with QtDBus")
        at /home/snoopy/kde/src/qtbase/src/corelib/global/qlogging.cpp:883
    #8  0x00007ffff5747dfc in QDBusPendingCallPrivate::setMetaTypes (this=0x555556ba6290, count=-32016, types=0x7fffffff8190) at /home/snoopy/kde/src/qtbase/src/dbus/qdbuspendingcall.cpp:170
    #9  QDBusPendingCallPrivate::setMetaTypes (this=0x555556ba6290, count=count@entry=6, types=types@entry=0x7fffffff82c0) at /home/snoopy/kde/src/qtbase/src/dbus/qdbuspendingcall.cpp:158
    #10 0x00007ffff5749d24 in QDBusPendingReplyBase::setMetaTypes (this=0x7fffffff8340, count=6, types=0x7fffffff82c0) at /home/snoopy/kde/src/qtbase/src/corelib/global/qcomparehelpers.h:1100
    #11 0x00007fffe00a4438 in QDBusPendingReply<bool, QList<QString>, PackageKit::Transaction::Role, long long, PackageKit::Transaction::Error, QString>::calculateMetaTypes (this=0x7fffffff8340)
        at /usr/include/c++/14/array:282
    #12 QDBusPendingReply<bool, QList<QString>, PackageKit::Transaction::Role, long long, PackageKit::Transaction::Error, QString>::calculateMetaTypes (this=0x7fffffff8340)
        at /opt/qt/include/QtDBus/qdbuspendingreply.h:107
    #13 QDBusPendingReply<bool, QList<QString>, PackageKit::Transaction::Role, long long, PackageKit::Transaction::Error, QString>::assign (this=0x7fffffff8340, call=...)
        at /opt/qt/include/QtDBus/qdbuspendingreply.h:121
    #14 QDBusPendingReply<bool, QList<QString>, PackageKit::Transaction::Role, long long, PackageKit::Transaction::Error, QString>::operator= (this=0x7fffffff8340, call=...)
        at /opt/qt/include/QtDBus/qdbuspendingreply.h:72
    #15 QDBusPendingReply<bool, QList<QString>, PackageKit::Transaction::Role, long long, PackageKit::Transaction::Error, QString>::QDBusPendingReply (this=0x7fffffff8340, call=...)
        at /opt/qt/include/QtDBus/qdbuspendingreply.h:65
    #16 PackageKit::Offline::getResults (this=this@entry=0x55555576cda0) at /home/snoopy/kde/src/packagekit-qt/src/offline.cpp:144
    #17 0x00007fffe014f7d8 in PackageKitUpdater::prepare (this=0x55555575e030) at /home/snoopy/kde/src/discover/libdiscover/backends/PackageKitBackend/PackageKitUpdater.cpp:346
    #18 0x00007ffff7cd7978 in ResourcesUpdatesModel::prepare (this=0x555556b663a0) at /home/snoopy/kde/src/discover/libdiscover/resources/ResourcesUpdatesModel.cpp:215
    #19 0x00007ffff7cbb794 in UpdateModel::activityChanged (this=0x555556ba2830) at /home/snoopy/kde/src/discover/libdiscover/UpdateModel/UpdateModel.cpp:96
    #20 UpdateModel::activityChanged (this=0x555556ba2830) at /home/snoopy/kde/src/discover/libdiscover/UpdateModel/UpdateModel.cpp:92
    #21 0x00007ffff65b74c4 in QQmlPropertyData::writeProperty (this=<optimized out>, target=<optimized out>, value=0x7fffffff8468, flags=...)
        at /home/snoopy/kde/src/qtdeclarative/src/qml/qml/qqmlpropertydata_p.h:344
    #22 QObjectPointerBinding::compareAndSet<QObjectPointerBinding::write(QV4::Value const&, bool, QFlags<QQmlPropertyData::WriteFlag>)::{lambda()#1}>(QQmlMetaObject const&, QObject*, QQmlPropertyData const*, QFlags<QQmlPropertyData::WriteFlag>, QObjectPointerBinding::write(QV4::Value const&, bool, QFlags<QQmlPropertyData::WriteFlag>)::{lambda()#1} const&) const
        (this=<optimized out>, resultMo=<optimized out>, resultObject=0x555556b663a0, pd=<optimized out>, flags=..., slowWrite=<optimized out>)
        at /home/snoopy/kde/src/qtdeclarative/src/qml/qml/qqmlbinding.cpp:831
    #23 QObjectPointerBinding::write (this=0x555556bac440, result=..., isUndefined=<optimized out>, flags=...) at /home/snoopy/kde/src/qtdeclarative/src/qml/qml/qqmlbinding.cpp:818
    #24 0x00007ffff65b1908 in QQmlBinding::doUpdate (this=0x555556bac440, watcher=..., flags=..., scope=...) at /home/snoopy/kde/src/qtdeclarative/src/qml/qml/qqmlbinding.cpp:715
    #25 0x00007ffff65b4df4 in QQmlBinding::update (this=0x555556bac440, flags=...) at /home/snoopy/kde/src/qtdeclarative/src/qml/qml/qqmlbinding.cpp:165
    #26 0x00007ffff6652240 in QQmlObjectCreator::finalize (this=0x5555556e31d0, interrupt=...) at /home/snoopy/kde/src/qtdeclarative/src/qml/qml/qqmlobjectcreator.cpp:1538
    #27 0x00007ffff65d002c in QQmlComponentPrivate::complete (enginePriv=0x5555556edc70, state=state@entry=0x5555569661d8) at /home/snoopy/kde/src/qtdeclarative/src/qml/qml/qqmlcomponent.cpp:1228
    #28 0x00007ffff65d5c14 in QQmlComponentPrivate::completeCreate (this=0x555556966120) at /home/snoopy/kde/src/qtdeclarative/src/qml/qml/qqmlcomponent.cpp:1345
    #29 0x00007ffff65d688c in QQmlComponent::completeCreate (this=0x5555563301b0) at /home/snoopy/kde/src/qtdeclarative/src/qml/qml/qqmlcomponent.cpp:1311
    #30 QQmlComponentPrivate::createWithProperties
        (this=0x555556966120, parent=parent@entry=0x0, properties=..., context=<optimized out>, behavior=behavior@entry=QQmlComponentPrivate::CreateDefault, createFromQml=createFromQml@entry=false) at /home/snoopy/kde/src/qtdeclarative/src/qml/qml/qqmlcomponent.cpp:1001
    #31 0x00007ffff65d6ae4 in QQmlComponent::createWithInitialProperties (this=this@entry=0x5555563301b0, initialProperties=..., context=<optimized out>)
        at /home/snoopy/kde/src/qtdeclarative/src/qml/qml/qqmlcomponent.cpp:967
```
