### PR TITLE
offline: Fix property invalidation

### DIFF
--- a/src/offline_p.h
+++ b/src/offline_p.h
@@ -40,10 +40,7 @@ public:
     OrgFreedesktopPackageKitOfflineInterface iface;
     QVariantMap preparedUpgrade;
     Offline::Action triggerAction = Offline::ActionUnset;
-    bool updatePrepared = false;
-    bool updateTriggered = false;
-    bool upgradePrepared = false;
-    bool upgradeTriggered = false;
+    QMap<QString, bool> m_properties;
 };
 }
 


### PR DESCRIPTION
We'd get a warning every time there's an invalidated property which it's really often.
The previous behaviour was incorrect to because invalidations were getting ignored.