### PR TITLE
PackageKit::Offline::Results: Make castable to QDBusPendingCall

### DIFF
--- a/src/offline.h
+++ b/src/offline.h
@@ -66,6 +66,8 @@ public:
         qulonglong timeFinished() const;
         Transaction::Error error() const;
         QString errorDescription() const;
+
+        operator QDBusPendingCall() const { return m_reply; }
     private:
         QDBusPendingReply<bool, QStringList, quint32, qulonglong, quint32, QString> m_reply;
     };


### PR DESCRIPTION
This makes it possible to feed the Results object into QDBusPendingCallWatcher